### PR TITLE
Added total viewers to the API output - Untested

### DIFF
--- a/app.py
+++ b/app.py
@@ -619,7 +619,7 @@ def stream_json():
         elif "youtube.com" in url:
             url_data = urlparse(url)
             video_id = parse_qs(url_data.query)["v"][0]
-            return requests.get("https://www.youtube.com/live_stats?v=" + video_id).text
+            return int(requests.get("https://www.youtube.com/live_stats?v=" + video_id).text)
 
     def make_dict(stream):
         return {'username': stream.streamer.reddit_username if stream.streamer else None,


### PR DESCRIPTION
I've added the code implemented in the sidebar bot into the main bot.
It is currently untested so its probably a good idea to check it before using it in production however I don't see why it wouldn't work though.

Future options could be to store the output to the database, with the option to see how many people watched a past broadcast when it was live perhaps?
